### PR TITLE
use identifier not id for dataset filtering in stub store

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -38,7 +38,7 @@ def datasets(request: Request, response: Response):
 def dataset_by_id(request: Request, response: Response, id: str):
     metadata_store = app.state.stores["dataset_metadata"]
     if request.headers['Accept'] == JSONLD or BROWSABLE:
-        datasets = metadata_store.get_dataset_by_id(id)
+        datasets = metadata_store.get_dataset(id)
         if len(datasets) == 1:
             response.status_code = status.HTTP_200_OK
             return datasets[0]
@@ -63,7 +63,7 @@ def publishers(request: Request, response: Response):
 def publisher_by_id(request: Request, response: Response, id: str):
     metadata_store = app.state.stores["publisher_metadata"]
     if request.headers['Accept'] == JSONLD or BROWSABLE:
-        publishers = metadata_store.get_publisher_by_id(id)
+        publishers = metadata_store.get_publisher(id)
         if len(publishers) == 1:
             response.status_code = status.HTTP_200_OK
             return publishers[0]
@@ -87,7 +87,7 @@ def topics(request: Request, response: Response):
 def topic_by_id(request: Request, response: Response, id: str):
     metadata_store = app.state.stores["topic_metadata"]
     if request.headers['Accept'] == JSONLD or BROWSABLE:
-        themes = metadata_store.get_topic_by_id(id)
+        themes = metadata_store.get_topic(id)
         if len(themes) == 1:
             response.status_code = status.HTTP_200_OK
             return themes[0]

--- a/src/store/stub/store.py
+++ b/src/store/stub/store.py
@@ -26,14 +26,14 @@ class StubStore(BaseStore):
         with open(Path(content_dir / "topics.json").absolute()) as f:
             self.themes = json.load(f)
 
-    def get_dataset_by_id(self, id: str) -> List[dict]:
-        return [x for x in self.datasets["items"] if x["id"] == id]
+    def get_dataset(self, id: str) -> List[dict]:
+        return [x for x in self.datasets["items"] if x["identifier"] == id]
 
-    def get_publisher_by_id(self, id: str) -> List[dict]:
-        return [x for x in self.publishers["items"] if x["id"] == id]
+    def get_publisher(self, id: str) -> List[dict]:
+        return [x for x in self.publishers["items"] if x["identifier"] == id]
     
-    def get_topic_by_id(self, id: str) -> List[dict]:
-        return [x for x in self.themes["items"] if x["id"] == id]
+    def get_topic(self, id: str) -> List[dict]:
+        return [x for x in self.themes["items"] if x["identifier"] == id]
     
     def get_datasets(self) -> dict:
         return self.datasets

--- a/src/store/stub/store.py
+++ b/src/store/stub/store.py
@@ -24,7 +24,7 @@ class StubStore(BaseStore):
             self.publishers = json.load(f)
 
         with open(Path(content_dir / "topics.json").absolute()) as f:
-            self.themes = json.load(f)
+            self.topics = json.load(f)
 
     def get_dataset(self, id: str) -> List[dict]:
         return [x for x in self.datasets["items"] if x["identifier"] == id]
@@ -33,7 +33,7 @@ class StubStore(BaseStore):
         return [x for x in self.publishers["items"] if x["identifier"] == id]
     
     def get_topic(self, id: str) -> List[dict]:
-        return [x for x in self.themes["items"] if x["identifier"] == id]
+        return [x for x in self.topics["items"] if x["identifier"] == id]
     
     def get_datasets(self) -> dict:
         return self.datasets
@@ -42,4 +42,4 @@ class StubStore(BaseStore):
         return self.publishers
     
     def get_topics(self) -> dict:
-        return self.themes
+        return self.topics


### PR DESCRIPTION
some tweaks to the stubbed store and endpoints:

- change method names to be a little less verbose.
- use "identifier" for filtering individual dataset items (was assume id, but its identifier in the csvw's).