### PR TITLE
fix Dockerfile for fastapi on port 8000

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,4 +15,4 @@ RUN pip install -r requirements.txt
 
 #start uvicorn in application
 WORKDIR /app/src
-CMD ["uvicorn", "main:app", "--reload"]
+CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000"]


### PR DESCRIPTION
Update the docker start command to get the fastapi server working as expected on k8s.