### PR TITLE
corrections to CPIH metadata

### DIFF
--- a/src/store/metadata/stub/content/editions/cpih_2022-01.json
+++ b/src/store/metadata/stub/content/editions/cpih_2022-01.json
@@ -16,7 +16,7 @@
             "creator": "office-for-national-statistics",
             "contact_point": {
               "name": "Consumer Price Inflation Enquiries",
-              "email": "mailto:cpih@ons.gov.uk"
+              "email": "mailto:cpi@ons.gov.uk"
             },
             "topics": [
               "https://staging.idpd.uk/topics/economy"
@@ -24,9 +24,10 @@
             "frequency": "monthly",
             "keywords": ["inflation", "consumer price index", "CPIH"],
             "licence": "http://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/",
-            "issued": "2017-02-21T09:30:00Z",
-            "modified": "2017-02-21T09:30:00Z",
+            "issued": "2022-02-16T09:30:00Z",
+            "modified": "2022-02-16T09:30:00Z",
             "spatial_coverage": "K02000001",
+            "spatial_resolution": ["K02"],
             "versions_url": "https://staging.idpd.uk/datasets/cpih/editions/2022-01/versions",
             "versions": [
               {
@@ -35,7 +36,12 @@
                 "modified": "2017-01-01T00:00:00"
               }
             ],
-            "temporal_coverage": "P33Y1M",
+            "temporal_coverage":
+              {
+                "start_date": "1989-01-01",
+                "end_date": "2022-01-31"
+              },
+            "temporal_resolution": ["P1M", "P1Q", "P1Y"],
             "next_release": "2017-03-11T09:30:00Z",
             "table_schema": {
               "columns": [


### PR DESCRIPTION
Clarifying spatial/temporal resolution/coverage.

## Spatial Resolution
The list of geography levels contained within the dataset, generally the first three characters of the ONS geography code.

e.g. a dataset that contains LSOA, and England, only would have a `spatial_resolution` of `["E01", "E92"]`.

## Spatial Coverage
This dataset only has English geographies so it's lowest layer of geography which encompasses the set of geographies is England.

e.g. a dataset which only contains English geographies would most likely have an expase of England, and `spatial_coverage` would be `"E92000001"`

## Temporal resolution
For all `refPeriod`s, they will be converted to ISO8601 period fragments, and represented as a list.

e.g. a dataset which contains monthly, quarterly (doesn't matter which type of quarters), or annual data (doesn't matter government or calendar years) would have a `temporal_resolution` of `["P1M", "P1Q", "P1Y"]`

## Temporal coverage
For all refPeriods, we take the first instant included in the oldest observation `refPeriod`, and most recent instant in the latest observation `refPeriod`, these are put in to `start_date` and `end_date` respectively of a `dcterms:PeriodOfTime` object (blank node via `temporal_resolution`)

e.g. the CPIH dataset is released monthly. It covers months, quarters, and years since 1 January 1989. The January 2022 release contains a January 2022 month, but not a Q1 2022 quarter, nor a 2022 year, so the `start_date` is `1989-01-01` and `end_date` is `2022-01-31`.