### PR TITLE
should not have a title at the /datasets level

### DIFF
--- a/src/schemas.py
+++ b/src/schemas.py
@@ -146,7 +146,6 @@ class Datasets(BaseModel):
     context: str = Field(alias="@context")
     id: str = Field(alias="@id")
     type: List[str] = Field(alias="@type")
-    title: str = Field(max_length=90)
     datasets: List  # TODO - stricter
     offset: int
     count: int

--- a/src/store/metadata/stub/content/datasets.json
+++ b/src/store/metadata/stub/content/datasets.json
@@ -2,7 +2,6 @@
     "@context": "https://staging.idpd.uk/#ns",
     "@type": ["dcat:Catalog", "hydra:Collection"],
     "@id": "http://localhost:8000/datasets",
-    "title": "Consumer Price Inflation including owner occupiers' housing costs (CPIH)",
     "datasets": [
         {
             "@id": "https://staging.idpd.uk/datasets/cpih",


### PR DESCRIPTION
We have a title field at the /datasets level which doesnt make sense (its a list of **all** datasets, not just cpih).

this removes it and updates the schema accordingly.