### PR TITLE
simple test runner action

### DIFF
--- a/.github/workflows.yaml
+++ b/.github/workflows.yaml
@@ -1,0 +1,17 @@
+name: Python Unit Tests
+
+on: [push]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.9'
+      - name: Run Pytest
+        run: pipenv run pytest --cov-report term-missing --cov=src --cov-config=./tests/coverage.rc ./tests/

--- a/.github/workflows.yaml
+++ b/.github/workflows.yaml
@@ -13,5 +13,12 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: '3.9'
+
+      - name: Install pipenv
+        run: pip install pipenv
+
+      - name: Install Tests Deoendencies
+        run: pipenv sync --dev
+
       - name: Run Pytest
         run: pipenv run pytest --cov-report term-missing --cov=src --cov-config=./tests/coverage.rc ./tests/

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -17,7 +17,7 @@ jobs:
       - name: Install pipenv
         run: pip install pipenv
 
-      - name: Install Tests Deoendencies
+      - name: Install test dependencies
         run: pipenv sync --dev
 
       - name: Run Pytest


### PR DESCRIPTION
Adds a simple simple github action test runner to run the unit tests whenever someone pushes to a branch of this repo. Just runs the tests and echoes out a test coverage report (exactly the same thing you get if you `make test` locally).

This is **not** the long term plan (will be run by GCP) but its a pretty good interim until that gets sorted out.

By way of "does it work" there should be a "checks passed" notification lower on this page so it does, if you click into that you'll see pytest things. Just need a sanity check really.

