### PR TITLE
add missing context item for modified

### DIFF
--- a/src/store/metadata/context.json
+++ b/src/store/metadata/context.json
@@ -59,6 +59,10 @@
     "licence": {
         "@id": "dcterms:license"
     },
+    "modified": {
+        "@id": "dcterms:modified",
+        "@type": "xsd:dateTime"
+    },
     "next_release": {
         "@id": "ons:nextRelease",
         "@type": "xsd:dateTime"


### PR DESCRIPTION
our temporary context is missing a definition for "modified" which makes it impossible to get that triple into or out of oxigraph even though there's a modified field in the datasets.json (its basically not getting loaded in so sparql queries looking for it will always fail).

this corrects that.

## How to review

If you `make data` without this change and look at `./out.ttl` you won't be able to find any `dcterms:modified` predicates in the data.

If you `make data` with this change you will.

