### PR TITLE
support multiple editions and versions in stubs

### DIFF
--- a/src/store/csv/stub/store.py
+++ b/src/store/csv/stub/store.py
@@ -1,3 +1,4 @@
+import glob
 from pathlib import Path
 
 from fastapi.responses import FileResponse
@@ -15,10 +16,17 @@ class StubCsvStore(BaseCsvStore):
     def setup(self):
         self.datasets = {}
 
-        content_dir = Path(Path(__file__).parent / "content")
-        self.datasets["cpih/2022-01/1"] = Path(
-            content_dir / "cpih/2022-01/1.csv"
-        ).absolute()
+        content_dir = Path(Path(__file__).parent / "content").absolute()
+        csv_file_paths = glob.glob(f'{content_dir}/**/**/*.csv', recursive=True)
+
+        # set as glob'ing multiple wildcard dirs can result in multiple hits for a single file
+        for csv_file_path in set(csv_file_paths):
+
+            # Create a key of dataset_id/edition_id/verion_id
+            csv_key = "/".join(csv_file_path.split("/")[-3:]).rstrip(".csv")
+
+            # Now add to dict so we can find them when a user requests
+            self.datasets[csv_key] = csv_file_path
 
     def get_version(self, dataset_id: str, edition_id: str, version_id: str):
         # Use variables to create the unique custom identifier for the csv

--- a/src/store/metadata/stub/store.py
+++ b/src/store/metadata/stub/store.py
@@ -1,4 +1,5 @@
 import json
+import glob
 import os
 from pathlib import Path
 from typing import Dict
@@ -57,26 +58,31 @@ class StubMetadataStore(BaseMetadataStore):
         """
         content_dir = Path(Path(__file__).parent / "content")
 
+        # get specific stubbed resources into memory on application startup
         with open(Path(content_dir / "datasets.json").absolute()) as f:
             self.datasets = json.load(f)
-
-        # TODO - grep the whole folder for editions json's, use dataset_id and
-        # edition_id as key in data holding dict
-        with open(Path(content_dir / "editions/cpih_2022-01.json").absolute()) as f:
-            self.editions = {"cpih_2022-01": json.load(f)}
-
-        # TODO - grep the whole folder for editions json's, use dataset_id and
-        # edition_id as key in data holding dict
-        with open(
-            Path(content_dir / "editions/versions/cpih_2022-01.json").absolute()
-        ) as f:
-            self.versions = {"cpih_2022-01": json.load(f)}
 
         with open(Path(content_dir / "publishers.json").absolute()) as f:
             self.publishers = json.load(f)
 
         with open(Path(content_dir / "topics.json").absolute()) as f:
             self.topics = json.load(f)
+
+        # for editions and versions we glob the directories in question
+        # and scoop up all jsons. We use the naming conventions of
+        # <dataset_id>_<edition_id> to populate the keys so we can get
+        # them back out
+        editions_dir = Path(content_dir / "editions")
+        self.editions = {}
+        for edition_json_file in glob.glob(os.path.join(editions_dir, "*.json")):
+            with open(edition_json_file) as f:
+                self.editions[edition_json_file.split("/")[-1].rstrip(".json")] = json.load(f)
+
+        versions_dir = Path(editions_dir / "versions")
+        self.versions = {}
+        for version_json_file in glob.glob(os.path.join(versions_dir, "*.json")):
+            with open(version_json_file) as f:
+                self.versions[version_json_file.split("/")[-1].rstrip(".json")] = json.load(f)
 
     def get_datasets(self) -> Dict:
         return contextualise(self.datasets)


### PR DESCRIPTION
addressing some TODO comments that have been around for a while - this PR allows the metadata and csv stub to populate itself more than one edition and version json.

it's literally just "glob all the files" rather than "read _the_ file".

## how to review

- confirm you can make start and make test and the expected things happen.
- sanity check