### PR TITLE
moved changes from 58-get-version to this branch

### DIFF
--- a/src/store/metadata/context.json
+++ b/src/store/metadata/context.json
@@ -161,5 +161,8 @@
     "titles": {
         "@id": "csvw:titles",
         "@language": "en"
+    },
+    "media_type" : {
+        "@id" : "dcterms:MediaType"
     }
 }

--- a/src/store/metadata/oxigraph/sparql/construct.py
+++ b/src/store/metadata/oxigraph/sparql/construct.py
@@ -363,3 +363,50 @@ def construct_edition_temporal_coverage(
     results_graph = graph.query(query).graph
     result = results_graph if results_graph else Graph()
     return result
+
+def construct_dataset_version(
+    graph: Graph, dataset_id: str, edition_id: str, version_id: str
+) -> Graph:
+    query = """
+        PREFIX dcat: <http://www.w3.org/ns/dcat#>
+        PREFIX dcterms: <http://purl.org/dc/terms/>
+        PREFIX csvw: <https://www.w3.org/ns/csvw#>
+        CONSTRUCT WHERE {{
+        <https://staging.idpd.uk/datasets/{dataset_id}/editions/{edition_id}/versions/{version_id}> a ?type ;
+        dcterms:identifier ?identifier ;
+        dcterms:title ?title ;
+        dcterms:description ?description ;
+        dcterms:abstract ?summary ;
+        dcterms:issued ?release_date ;
+        dcat:downloadUrl ?download_url ;
+        dcterms:MediaType ?mediatype .
+        }}
+        """.format(dataset_id=dataset_id, edition_id=edition_id, version_id=version_id
+    )
+
+    results_graph = graph.query(query).graph
+    result = results_graph if results_graph else Graph()
+    return result
+
+def construct_dataset_version_table_schema(
+    graph: Graph, dataset_id: str, edition_id: str, version_id: str
+) -> Graph:
+    query = """
+        PREFIX dcterms: <http://purl.org/dc/terms/>
+        PREFIX csvw: <https://www.w3.org/ns/csvw#>
+        CONSTRUCT WHERE {{
+            <https://staging.idpd.uk/datasets/{dataset_id}/editions/{edition_id}/versions/{version_id}> a ?type  ;
+        csvw:schema ?table_schema .
+            ?table_schema csvw:column ?columns .
+            ?columns csvw:name ?name ;
+                    csvw:datatype ?datatype ;
+                    dcterms:description ?description ;
+                    csvw:titles ?titles .
+        }}
+        """.format(
+        dataset_id=dataset_id, edition_id=edition_id, version_id=version_id
+    )
+
+    results_graph = graph.query(query).graph
+    result = results_graph if results_graph else Graph()
+    return result

--- a/tests/store/metadata/oxigraph/test_oxigraph_version.py
+++ b/tests/store/metadata/oxigraph/test_oxigraph_version.py
@@ -1,0 +1,43 @@
+import os
+import pytest
+
+from pydantic import ValidationError
+
+from store.metadata.oxigraph.store import OxigraphMetadataStore
+import schemas
+
+
+def test_oxigraph_get_version_returns_valid_structure():
+    """
+    Confirm that the OxigraphMetadataStore.get_version()
+    function returns a version with table schema that matches the version
+    schema.
+    """
+    store = OxigraphMetadataStore()
+
+    version = store.get_version(dataset_id="cpih", edition_id="2022-01", version_id="1")
+    version_schema = schemas.Version(**version)
+
+    assert (
+        version_schema.id
+        == "https://staging.idpd.uk/datasets/cpih/editions/2022-01/versions/1"
+    )
+    assert "dcat:Distribution" in version_schema.type
+    assert "csvw:Table" in version_schema.type
+    assert version_schema.identifier == "1"
+    assert (
+        version_schema.title
+        == "Consumer Prices Index including owner occupiers' housing costs (CPIH)"
+    )
+    assert version_schema.issued == "2017-01-01T00:00:00"
+    assert (
+        version_schema.summary
+        == "The Consumer Prices Index including owner occupiers' housing costs (CPIH) is a..."
+    )
+    assert version_schema.description == "The Consumer Prices Index..."
+    assert (
+        version_schema.download_url
+        == "https://staging.idpd.uk/datasets/cpih/editions/2022-01/versions/1.csv"
+    )
+    assert version_schema.media_type == "text/csv"
+    assert len(version_schema.table_schema.columns) == 4

--- a/tests/store/metadata/oxigraph/test_oxigraph_version.py
+++ b/tests/store/metadata/oxigraph/test_oxigraph_version.py
@@ -15,7 +15,7 @@ def test_oxigraph_get_version_returns_valid_structure():
     """
     store = OxigraphMetadataStore()
 
-    version = store.get_version(dataset_id="cpih", edition_id="2022-01", version_id="1")
+    version = store.get_version("cpih", "2022-01", "1")
     version_schema = schemas.Version(**version)
 
     assert (
@@ -41,3 +41,8 @@ def test_oxigraph_get_version_returns_valid_structure():
     )
     assert version_schema.media_type == "text/csv"
     assert len(version_schema.table_schema.columns) == 4
+
+def test_version_schema_validation():
+    """Confirm that the schema validation is working as intended i.e raises ValidationError with wrong structure"""
+    with pytest.raises(ValidationError):
+        schemas.Version(**{"I": "break"})


### PR DESCRIPTION
adding get_version() and the test_oxigraph_get_version_returns_valid_structure(), found at /tests/store/metadata/oxigraph/test_oxigraph_version.py should pass