### PR TITLE
165 log out request

### DIFF
--- a/src/custom_logging.py
+++ b/src/custom_logging.py
@@ -1,5 +1,6 @@
 import logging
 import sys
+from typing import Optional
 
 import structlog
 
@@ -46,10 +47,8 @@ class DpLogger:
 def generate_trace_id():
     return "your_trace_id"
 
-
 def generate_span_id():
     return "your_span_id"
-
 
 def configure_logger(enable_json_logs: bool = False):
     timestamper = structlog.processors.TimeStamper(fmt="%Y-%m-%d %H:%M:%S")
@@ -71,7 +70,11 @@ def configure_logger(enable_json_logs: bool = False):
                 structlog.processors.CallsiteParameter.PROCESS_NAME,
             }
         ),
-        structlog.stdlib.ExtraAdder(),
+        structlog.stdlib.ExtraAdder(
+            {
+                "request_id",
+            }
+        ),
     ]
 
     structlog.configure(

--- a/src/store/csv/stub/store.py
+++ b/src/store/csv/stub/store.py
@@ -1,12 +1,14 @@
 import glob
 from pathlib import Path
+from typing import Optional
 
 from fastapi.responses import FileResponse
 
-from custom_logging import logger
+from custom_logging import logger, configure_logger
 
 from ..base import BaseCsvStore
 
+configure_logger()
 
 class StubCsvStore(BaseCsvStore):
     """
@@ -28,7 +30,7 @@ class StubCsvStore(BaseCsvStore):
             # Now add to dict so we can find them when a user requests
             self.datasets[csv_key] = csv_file_path
 
-    def get_version(self, dataset_id: str, edition_id: str, version_id: str):
+    def get_version(self, dataset_id: str, edition_id: str, version_id: str, request_id:Optional[str] = None):
         # Use variables to create the unique custom identifier for the csv
         # being requested.
         csv_identifier = f"{dataset_id}/{edition_id}/{version_id}".rstrip(".csv")
@@ -40,6 +42,7 @@ class StubCsvStore(BaseCsvStore):
                 "version_id": version_id,
                 "combined_csv_id": csv_identifier,
             },
+            request_id=request_id,
         )
 
         # Try and get it, then log out whether or not we did.
@@ -51,6 +54,7 @@ class StubCsvStore(BaseCsvStore):
                 "csv_ids_in_store": list(self.datasets.keys()),
                 "csv_acquired": False if csv_path is None else True,
             },
+            request_id=request_id,
         )
 
         return FileResponse(csv_path) if csv_path else None

--- a/src/store/metadata/context.py
+++ b/src/store/metadata/context.py
@@ -1,6 +1,10 @@
 import json
 from pathlib import Path
+from typing import Optional
 
+from custom_logging import configure_logger, logger
+
+configure_logger()
 
 class ContextStore:
     def __init__(self):
@@ -8,5 +12,6 @@ class ContextStore:
         with open(Path(this_dir / "context.json").absolute(), "r") as json_file:
             self.context = json.load(json_file)
 
-    def get_context(self):
+    def get_context(self, request_id: Optional[str] = None):
+        logger.info("Getting Context", request_id=request_id)
         return self.context

--- a/src/store/metadata/oxigraph/store.py
+++ b/src/store/metadata/oxigraph/store.py
@@ -7,12 +7,13 @@ from pyld import jsonld
 from rdflib import Dataset, Graph, URIRef
 from rdflib.plugins.stores.sparqlstore import SPARQLUpdateStore
 
-from custom_logging import logger
+from custom_logging import logger , configure_logger
 from store.metadata.sparql import SparqlQueries
 
 from .. import constants
 from ..base import BaseMetadataStore
 
+configure_logger()
 
 class OxigraphMetadataStore(BaseMetadataStore):
     def setup(self):
@@ -26,11 +27,11 @@ class OxigraphMetadataStore(BaseMetadataStore):
         self.db = Dataset(store=SPARQLUpdateStore(*configuration))
         self.sparql_queries = SparqlQueries(self.db)
 
-    def get_datasets(self) -> Optional[Dict]:
+    def get_datasets(self, request_id:Optional[str] = None) -> Optional[Dict]:
         """
         Gets all datasets
         """
-        logger.info("Constructing get_datasets() response from graph")
+        logger.info("Constructing get_datasets() response from graph", request_id=request_id,)
 
         # Extract RDF triples from the database as one Graph
         result: Graph = self.sparql_queries.datasets()
@@ -66,13 +67,14 @@ class OxigraphMetadataStore(BaseMetadataStore):
         datasets_graph = {"@context": "https://staging.idpd.uk/ns#", **datasets_graph}
         return datasets_graph
 
-    def get_dataset(self, dataset_id: str) -> Optional[Dict]:
+    def get_dataset(self, dataset_id: str, request_id:Optional[str] = None) -> Optional[Dict]:
         """
         Get a dataset by its ID and return its metadata as a JSON-LD dict.
         """
         logger.info(
             "Constructing get_dataset() response from graph",
             data={"dataset_id": dataset_id},
+            request_id=request_id,
         )
 
         # Define initBindings for SPARQL query
@@ -133,13 +135,14 @@ class OxigraphMetadataStore(BaseMetadataStore):
         dataset_graph = {"@context": "https://staging.idpd.uk/ns#", **dataset_graph}
         return dataset_graph
 
-    def get_editions(self, dataset_id: str) -> Optional[Dict]:
+    def get_editions(self, dataset_id: str, request_id:Optional[str] = None) -> Optional[Dict]:
         """
         Gets all editions of a specific dataset with ID `dataset_id`
         """
         logger.info(
             "Constructing get_editions() response from graph",
             data={"dataset_id": dataset_id},
+            request_id=request_id,
         )
 
         # Define initBindings for SPARQL query
@@ -180,13 +183,14 @@ class OxigraphMetadataStore(BaseMetadataStore):
         editions_graph = {"@context": "https://staging.idpd.uk/ns#", **editions_graph}
         return editions_graph
 
-    def get_edition(self, dataset_id: str, edition_id: str) -> Optional[Dict]:
+    def get_edition(self, dataset_id: str, edition_id: str, request_id:Optional[str] = None) -> Optional[Dict]:
         """
         Gets a specific edition with ID `edition_id` of a specific dataset with ID `dataset_id`
         """
         logger.info(
             "Constructing get_edition() response from graph",
             data={"dataset_id": dataset_id, "edition_id": edition_id},
+            request_id=request_id,
         )
 
         # Define initBindings for SPARQL query
@@ -253,13 +257,14 @@ class OxigraphMetadataStore(BaseMetadataStore):
         edition_graph = {"@context": "https://staging.idpd.uk/ns#", **edition_graph}
         return edition_graph
 
-    def get_versions(self, dataset_id: str, edition_id: str) -> Optional[Dict]:
+    def get_versions(self, dataset_id: str, edition_id: str, request_id:Optional[str] = None) -> Optional[Dict]:
         """
         Gets all versions of a specific edition of a specific dataset
         """
         logger.info(
             "Constructing get_versions() response from graph",
             data={"dataset_id": dataset_id, "edition_id": edition_id},
+            request_id=request_id,
         )
 
         # Define initBindings for SPARQL query
@@ -299,7 +304,7 @@ class OxigraphMetadataStore(BaseMetadataStore):
         return versions_graph
 
     def get_version(
-        self, dataset_id: str, edition_id: str, version_id: str
+        self, dataset_id: str, edition_id: str, version_id: str, request_id:Optional[str] = None
     ) -> Optional[Dict]:
         """
         Gets a specific version of a specific edition of a specific dataset
@@ -311,6 +316,7 @@ class OxigraphMetadataStore(BaseMetadataStore):
                 "edition_id": edition_id,
                 "version_id": version_id,
             },
+            request_id=request_id,
         )
 
         # Define initBindings for SPARQL query
@@ -358,11 +364,11 @@ class OxigraphMetadataStore(BaseMetadataStore):
         version_graph = {"@context": "https://staging.idpd.uk/ns#", **version_graph}
         return version_graph
 
-    def get_publishers(self) -> Optional[Dict]:
+    def get_publishers(self, request_id:Optional[str] = None) -> Optional[Dict]:
         """
         Gets all publishers
         """
-        logger.info("Constructing get_publishers() response from graph")
+        logger.info("Constructing get_publishers() response from graph", request_id=request_id,)
 
         # Extract RDF triples from the database as one Graph
         result: Graph = self.sparql_queries.publishers()
@@ -396,13 +402,14 @@ class OxigraphMetadataStore(BaseMetadataStore):
         }
         return publishers_graph
 
-    def get_publisher(self, publisher_id: str) -> Optional[Dict]:
+    def get_publisher(self, publisher_id: str, request_id:Optional[str] = None) -> Optional[Dict]:
         """
         Get a specific publisher
         """
         logger.info(
             "Constructing get_publisher() response from graph",
             data={"publisher_id": publisher_id},
+            request_id=request_id,
         )
 
         # Define initBindings for SPARQL query
@@ -429,11 +436,11 @@ class OxigraphMetadataStore(BaseMetadataStore):
         publisher_graph = {"@context": "https://staging.idpd.uk/ns#", **publisher_graph}
         return publisher_graph
 
-    def get_topics(self) -> Optional[Dict]:
+    def get_topics(self, request_id:Optional[str] = None) -> Optional[Dict]:
         """
         Get all topics
         """
-        logger.info("Constructing get_topics() response from graph")
+        logger.info("Constructing get_topics() response from graph", request_id=request_id,)
 
         # Define initBindings for SPARQL query
         init_bindings = {
@@ -469,12 +476,14 @@ class OxigraphMetadataStore(BaseMetadataStore):
         topics_graph = {"@context": "https://staging.idpd.uk/ns#", **topics_graph}
         return topics_graph
 
-    def get_topic(self, topic_id: str) -> Optional[Dict]:
+    def get_topic(self, topic_id: str, request_id:Optional[str] = None) -> Optional[Dict]:
         """
         Get a specific topic by topic_id
         """
         logger.info(
-            "Constructing get_topic() response from graph", data={"topic_id": topic_id}
+            "Constructing get_topic() response from graph", 
+            data={"topic_id": topic_id},
+            request_id=request_id,
         )
 
         # Define initBindings for SPARQL query
@@ -509,13 +518,14 @@ class OxigraphMetadataStore(BaseMetadataStore):
         topic_graph = {"@context": "https://staging.idpd.uk/ns#", **topic_graph}
         return topic_graph
 
-    def get_sub_topics(self, topic_id: str) -> Optional[Dict]:
+    def get_sub_topics(self, topic_id: str, request_id:Optional[str] = None) -> Optional[Dict]:
         """
         Get all sub-topics for a specific topic
         """
         logger.info(
             "Constructing get_sub_topics() response from graph",
             data={"topic_id": topic_id},
+            request_id=request_id,
         )
 
         # Get all topics

--- a/src/store/metadata/stub/store.py
+++ b/src/store/metadata/stub/store.py
@@ -93,18 +93,18 @@ class StubMetadataStore(BaseMetadataStore):
                 ] = json.load(f)
 
     def get_datasets(self, request_id:Optional[str] = None) -> Dict:
-        logger.info("Getting Stubstore datasets", request_id=request_id)
+        logger.info("Constructing get_datasets() from files stored on disk", request_id=request_id)
         return contextualise(self.datasets)
 
     def get_dataset(self, id: str, request_id:Optional[str] = None) -> Dict:
-        logger.info("Getting Stubstore dataset", request_id=request_id)
+        logger.info("Constructing get_dataset() from files stored on disk", request_id=request_id)
         dataset = next(
             (x for x in self.datasets["datasets"] if x["identifier"] == id), None
         )
         return contextualise(dataset)
 
     def get_editions(self, dataset_id: str, request_id:Optional[str] = None) -> Dict:
-        logger.info("Getting Stubstore editions", request_id=request_id)
+        logger.info("Constructing get_editions() from files stored on disk", request_id=request_id)
         all_edition_keys = self.editions.keys()
         edition_key = next(
             (x for x in all_edition_keys if x.split("_")[0] == dataset_id),
@@ -113,7 +113,7 @@ class StubMetadataStore(BaseMetadataStore):
         return contextualise(self.editions.get(edition_key, None))
 
     def get_edition(self, dataset_id: str, edition_id: str, request_id:Optional[str] = None) -> Dict:
-        logger.info("Getting Stubstore edition", request_id=request_id)
+        logger.info("Constructing get_edition() from files stored on disk", request_id=request_id)
         editions_for_dataset = self.get_editions(dataset_id)
         if editions_for_dataset is None:
             return None
@@ -128,7 +128,7 @@ class StubMetadataStore(BaseMetadataStore):
         return contextualise(edition)
 
     def get_versions(self, dataset_id: str, edition_id: str, request_id:Optional[str] = None) -> Dict:
-        logger.info("Getting Stubstore versions", request_id=request_id)
+        logger.info("Constructing get_versions() from files stored on disk", request_id=request_id)
         all_version_keys = self.versions.keys()
         version_key = next(
             (x for x in all_version_keys if x == f"{dataset_id}_{edition_id}"),
@@ -137,7 +137,7 @@ class StubMetadataStore(BaseMetadataStore):
         return contextualise(self.versions.get(version_key, None))
 
     def get_version(self, dataset_id: str, edition_id: str, version_id: str, request_id:Optional[str] = None) -> Dict:
-        logger.info("Getting Stubstore versions", request_id=request_id)
+        logger.info("Constructing get_version() from files stored on disk", request_id=request_id)
         versions_for_dataset = self.get_versions(dataset_id, edition_id)
         if versions_for_dataset is None:
             return None
@@ -152,11 +152,11 @@ class StubMetadataStore(BaseMetadataStore):
         return contextualise(edition)
 
     def get_publishers(self, request_id:Optional[str] = None) -> Dict:
-        logger.info("Getting Stubstore publishers", request_id=request_id)
+        logger.info("Constructing get_publishers() from files stored on disk", request_id=request_id)
         return contextualise(self.publishers)
 
     def get_publisher(self, publisher_id: str, request_id:Optional[str] = None) -> Dict:
-        logger.info("Getting Stubstore publisher", request_id=request_id)
+        logger.info("Constructing get_publisher() from files stored on disk", request_id=request_id)
         publishers = self.get_publishers()
         if publishers is None:
             return None
@@ -172,11 +172,11 @@ class StubMetadataStore(BaseMetadataStore):
         )
 
     def get_topics(self, request_id:Optional[str] = None) -> Dict:
-        logger.info("Getting Stubstore topics", request_id=request_id)
+        logger.info("Constructing get_topics() from files stored on disk", request_id=request_id)
         return contextualise(self.topics)
 
     def get_topic(self, topic_id: str, request_id:Optional[str] = None) -> Dict:
-        logger.info("Getting Stubstore topic", request_id=request_id)
+        logger.info("Constructing get_topic() from files stored on disk", request_id=request_id)
         topics = self.get_topics()
         if topics is None:
             return None
@@ -188,7 +188,7 @@ class StubMetadataStore(BaseMetadataStore):
         )
 
     def get_sub_topics(self, topic_id: str, request_id:Optional[str] = None) -> Dict:
-        logger.info("Getting Stubstore sub_topics", request_id=request_id)
+        logger.info("Constructing get_sub_topics() from files stored on disk", request_id=request_id)
         topic = self.get_topic(topic_id)
         if topic is None:
             return None
@@ -214,5 +214,5 @@ class StubMetadataStore(BaseMetadataStore):
         )
 
     def get_sub_topic(self, topic_id: str, sub_topic_id: str, request_id:Optional[str] = None) -> Dict:
-        logger.info("Getting Stubstore sub_topic", request_id=request_id)
+        logger.info("Constructing get_sub_topic() from files stored on disk", request_id=request_id)
         raise NotImplementedError

--- a/src/store/metadata/stub/store.py
+++ b/src/store/metadata/stub/store.py
@@ -2,9 +2,13 @@ import glob
 import json
 import os
 from pathlib import Path
-from typing import Dict
+from typing import Dict, Optional
 
 from ..base import BaseMetadataStore
+
+from custom_logging import logger , configure_logger
+
+configure_logger()
 
 
 def recursive_replace(data, find, replace):
@@ -88,16 +92,19 @@ class StubMetadataStore(BaseMetadataStore):
                     version_json_file.split("/")[-1].rstrip(".json")
                 ] = json.load(f)
 
-    def get_datasets(self) -> Dict:
+    def get_datasets(self, request_id:Optional[str] = None) -> Dict:
+        logger.info("Getting Stubstore datasets", request_id=request_id)
         return contextualise(self.datasets)
 
-    def get_dataset(self, id: str) -> Dict:
+    def get_dataset(self, id: str, request_id:Optional[str] = None) -> Dict:
+        logger.info("Getting Stubstore dataset", request_id=request_id)
         dataset = next(
             (x for x in self.datasets["datasets"] if x["identifier"] == id), None
         )
         return contextualise(dataset)
 
-    def get_editions(self, dataset_id: str) -> Dict:
+    def get_editions(self, dataset_id: str, request_id:Optional[str] = None) -> Dict:
+        logger.info("Getting Stubstore editions", request_id=request_id)
         all_edition_keys = self.editions.keys()
         edition_key = next(
             (x for x in all_edition_keys if x.split("_")[0] == dataset_id),
@@ -105,7 +112,8 @@ class StubMetadataStore(BaseMetadataStore):
         )
         return contextualise(self.editions.get(edition_key, None))
 
-    def get_edition(self, dataset_id: str, edition_id: str) -> Dict:
+    def get_edition(self, dataset_id: str, edition_id: str, request_id:Optional[str] = None) -> Dict:
+        logger.info("Getting Stubstore edition", request_id=request_id)
         editions_for_dataset = self.get_editions(dataset_id)
         if editions_for_dataset is None:
             return None
@@ -119,7 +127,8 @@ class StubMetadataStore(BaseMetadataStore):
         )
         return contextualise(edition)
 
-    def get_versions(self, dataset_id: str, edition_id: str) -> Dict:
+    def get_versions(self, dataset_id: str, edition_id: str, request_id:Optional[str] = None) -> Dict:
+        logger.info("Getting Stubstore versions", request_id=request_id)
         all_version_keys = self.versions.keys()
         version_key = next(
             (x for x in all_version_keys if x == f"{dataset_id}_{edition_id}"),
@@ -127,7 +136,8 @@ class StubMetadataStore(BaseMetadataStore):
         )
         return contextualise(self.versions.get(version_key, None))
 
-    def get_version(self, dataset_id: str, edition_id: str, version_id: str) -> Dict:
+    def get_version(self, dataset_id: str, edition_id: str, version_id: str, request_id:Optional[str] = None) -> Dict:
+        logger.info("Getting Stubstore versions", request_id=request_id)
         versions_for_dataset = self.get_versions(dataset_id, edition_id)
         if versions_for_dataset is None:
             return None
@@ -141,10 +151,12 @@ class StubMetadataStore(BaseMetadataStore):
         )
         return contextualise(edition)
 
-    def get_publishers(self) -> Dict:
+    def get_publishers(self, request_id:Optional[str] = None) -> Dict:
+        logger.info("Getting Stubstore publishers", request_id=request_id)
         return contextualise(self.publishers)
 
-    def get_publisher(self, publisher_id: str) -> Dict:
+    def get_publisher(self, publisher_id: str, request_id:Optional[str] = None) -> Dict:
+        logger.info("Getting Stubstore publisher", request_id=request_id)
         publishers = self.get_publishers()
         if publishers is None:
             return None
@@ -159,10 +171,12 @@ class StubMetadataStore(BaseMetadataStore):
             )
         )
 
-    def get_topics(self) -> Dict:
+    def get_topics(self, request_id:Optional[str] = None) -> Dict:
+        logger.info("Getting Stubstore topics", request_id=request_id)
         return contextualise(self.topics)
 
-    def get_topic(self, topic_id: str) -> Dict:
+    def get_topic(self, topic_id: str, request_id:Optional[str] = None) -> Dict:
+        logger.info("Getting Stubstore topic", request_id=request_id)
         topics = self.get_topics()
         if topics is None:
             return None
@@ -173,7 +187,8 @@ class StubMetadataStore(BaseMetadataStore):
             )
         )
 
-    def get_sub_topics(self, topic_id: str) -> Dict:
+    def get_sub_topics(self, topic_id: str, request_id:Optional[str] = None) -> Dict:
+        logger.info("Getting Stubstore sub_topics", request_id=request_id)
         topic = self.get_topic(topic_id)
         if topic is None:
             return None
@@ -198,5 +213,6 @@ class StubMetadataStore(BaseMetadataStore):
             }
         )
 
-    def get_sub_topic(self, topic_id: str, sub_topic_id: str) -> Dict:
+    def get_sub_topic(self, topic_id: str, sub_topic_id: str, request_id:Optional[str] = None) -> Dict:
+        logger.info("Getting Stubstore sub_topic", request_id=request_id)
         raise NotImplementedError

--- a/tests/test_custom_logging.py
+++ b/tests/test_custom_logging.py
@@ -82,7 +82,7 @@ def test_oxigraph_get_versions_logger_request_id_is_none():
                 assert 'request_id' in log
                 assert 'log_level' in log
                 assert log.get('log_level') == 'info'
-                assert type(log.get('request_id')) == None
+                assert type(log.get('request_id')) == type(None)
 
 def test_context_store_logger_returns_request_id():
     with capture_logs() as cap_logs: 
@@ -106,7 +106,7 @@ def test_context_store_logger_request_id_is_none():
                 assert 'request_id' in log
                 assert 'log_level' in log
                 assert log.get('log_level') == 'info'
-                assert type(log.get('request_id')) == None
+                assert type(log.get('request_id')) == type(None)
 
 def test_csv_stub_logger_returns_request_id():
     """
@@ -116,7 +116,7 @@ def test_csv_stub_logger_returns_request_id():
     """
     with capture_logs() as cap_logs:
         csv_store = StubCsvStore()
-        csv = csv_store.get_version(request_id='96a101dd-c49a-4fea-aee2-a76510f32190')
+        csv = csv_store.get_version("cpih", "2022-01", "1", request_id='96a101dd-c49a-4fea-aee2-a76510f32190')
 
         for log in cap_logs:
             if log.get('event') == 'Recieved request for csv':
@@ -133,14 +133,14 @@ def test_csv_stub_logger_request_id_is_none():
     """
     with capture_logs() as cap_logs:
         csv_store = StubCsvStore()
-        csv = csv_store.get_version(request_id=None)
+        csv = csv_store.get_version("cpih", "2022-01", "1", request_id=None)
 
         for log in cap_logs:
             if log.get('event') == 'Recieved request for csv':
                 assert 'request_id' in log
                 assert 'log_level' in log
                 assert log.get('log_level') == 'info'
-                assert type(log.get('request_id')) == None
+                assert type(log.get('request_id')) == type(None)
 
 def test_stub_get_dataset_logger_returns_request_id():
     """
@@ -178,4 +178,4 @@ def test_stub_get_datasets_logger_request_id_is_none():
                 assert 'request_id' in log
                 assert 'log_level' in log
                 assert log.get('log_level') == 'info'
-                assert type(log.get('request_id')) == None
+                assert type(log.get('request_id')) == type(None)

--- a/tests/test_custom_logging.py
+++ b/tests/test_custom_logging.py
@@ -1,3 +1,5 @@
+import json
+from pathlib import Path
 from typing import Optional
 from structlog.testing import capture_logs
 from unittest.mock import MagicMock
@@ -12,11 +14,18 @@ from main import app, StubMetadataStore
 from tests.fixtures.versions import versions_test_data
 
 from store.metadata.oxigraph.store import OxigraphMetadataStore
+from store.metadata.context import ContextStore
 import schemas
+from starlette.responses import FileResponse
+
+from store.csv.stub.store import StubCsvStore
+
+from store.metadata.stub.store import StubMetadataStore
+from src import schemas
 
 ENDPOINT = "datasets/some-dataset-id/editions/some-edition-id/versions"
 
-def test_logger_request_id():
+def test_request_handlers_return_logger_request_id():
     """
     Confirms that:
 
@@ -39,7 +48,7 @@ def test_logger_request_id():
             if 'request_id' in log:
                 assert 'log_level' in log
                 assert log.get('log_level') == 'info'
-                assert type(log.get('request_id')) == Optional[int]
+                assert type(log.get('request_id')) == str
 
 def test_oxigraph_get_datasets_logger_returns_request_id():
     """
@@ -57,18 +66,116 @@ def test_oxigraph_get_datasets_logger_returns_request_id():
             assert log.get('log_level') == 'info'
             # assert type(log.get('request_id')) == None
 
-def test_oxigraph_get_versions_returns_valid_structure():
+def test_oxigraph_get_versions_logger_request_id_is_none():
     """
     Confirm that the OxigraphMetadataStore.get_versions()
     function returns a dictionary that matches the Versions
     schema.
     """
-    store = OxigraphMetadataStore()
-    versions = store.get_versions("4gc", "2023-09")
-    versions_schema = schemas.Versions(**versions)
-    assert (
-        versions_schema.id
-        == "https://staging.idpd.uk/datasets/4gc/editions/2023-09/versions"
-    )
-    assert versions_schema.type == "hydra:Collection"
-    assert len(versions_schema.versions) == versions_schema.count
+    with capture_logs() as cap_logs: 
+        store = OxigraphMetadataStore()
+        versions = store.get_versions("4gc", "2023-09", request_id=None)
+        versions_schema = schemas.Versions(**versions)
+        
+        for log in cap_logs:
+            # if 'request_id' in log:
+            assert 'request_id' in log
+            assert 'log_level' in log
+            assert log.get('log_level') == 'info'
+            # assert type(log.get('request_id')) == None
+
+def test_context_store_logger_returns_request_id():
+    with capture_logs() as cap_logs: 
+        context_store = ContextStore()
+        context = context_store.get_context(request_id=3)
+
+        for log in cap_logs:
+                # if 'request_id' in log:
+                assert 'request_id' in log
+                assert 'log_level' in log
+                assert log.get('log_level') == 'info'
+                # assert type(log.get('request_id')) == None
+
+def test_context_store_logger_request_id_is_none():
+    with capture_logs() as cap_logs: 
+        context_store = ContextStore()
+        context = context_store.get_context(request_id=None)
+
+        for log in cap_logs:
+                # if 'request_id' in log:
+                assert 'request_id' in log
+                assert 'log_level' in log
+                assert log.get('log_level') == 'info'
+                # assert type(log.get('request_id')) == None
+
+def test_csv_stub_logger_returns_request_id():
+    """
+    Just test the store can return a csv when we
+    ask for a csv that we know exists but do include
+    the ".csv" file extensions.
+    """
+    with capture_logs() as cap_logs:
+        csv_store = StubCsvStore()
+        csv = csv_store.get_version(request_id=3)
+
+        for log in cap_logs:
+                # if 'request_id' in log:
+                assert 'request_id' in log
+                assert 'log_level' in log
+                assert log.get('log_level') == 'info'
+                # assert type(log.get('request_id')) == None
+
+def test_csv_stub_logger_request_id_is_none():
+    """
+    Just test the store can return a csv when we
+    ask for a csv that we know exists but do include
+    the ".csv" file extensions.
+    """
+    with capture_logs() as cap_logs:
+        csv_store = StubCsvStore()
+        csv = csv_store.get_version(request_id=None)
+
+        for log in cap_logs:
+                # if 'request_id' in log:
+                assert 'request_id' in log
+                assert 'log_level' in log
+                assert log.get('log_level') == 'info'
+                # assert type(log.get('request_id')) == None
+
+def test_stub_get_dataset_logger_returns_request_id():
+    """
+    Confirm that the OxigrapgMetadataStore.get_dataset()
+    function returns a dataset that matches the dataset
+    schema.
+    """
+
+    with capture_logs() as cap_logs:
+        store = StubMetadataStore()
+
+        dataset = store.get_dataset("cpih",request_id=3)
+
+        for log in cap_logs:
+                # if 'request_id' in log:
+                assert 'request_id' in log
+                assert 'log_level' in log
+                assert log.get('log_level') == 'info'
+                # assert type(log.get('request_id')) == None
+
+def test_stub_get_datasets_logger_request_id_is_none():
+    """
+    Confirm that the OxigrapgMetadataStore.get_dataset()
+    function returns a dataset that matches the dataset
+    schema.
+    """
+
+    with capture_logs() as cap_logs:
+        store = StubMetadataStore()
+
+        datasets = store.get_datasets(request_id=None)
+
+        for log in cap_logs:
+                # if 'request_id' in log:
+                assert 'request_id' in log
+                assert 'log_level' in log
+                assert log.get('log_level') == 'info'
+                # assert type(log.get('request_id')) == None

--- a/tests/test_custom_logging.py
+++ b/tests/test_custom_logging.py
@@ -56,15 +56,15 @@ def test_oxigraph_get_datasets_logger_returns_request_id():
     """  
     with capture_logs() as cap_logs:    
         store = OxigraphMetadataStore()
-        datasets = store.get_datasets(request_id=8)
+        datasets = store.get_datasets(request_id='96a101dd-c49a-4fea-aee2-a76510f32190')
         datasets_schema = schemas.Datasets(**datasets)
 
         for log in cap_logs:
-            # if 'request_id' in log:
-            assert 'request_id' in log
-            assert 'log_level' in log
-            assert log.get('log_level') == 'info'
-            # assert type(log.get('request_id')) == None
+            if log.get('event') == 'Constructing get_datasets() response from graph':
+                assert 'request_id' in log
+                assert 'log_level' in log
+                assert log.get('log_level') == 'info'
+                assert type(log.get('request_id')) == str
 
 def test_oxigraph_get_versions_logger_request_id_is_none():
     """
@@ -78,23 +78,23 @@ def test_oxigraph_get_versions_logger_request_id_is_none():
         versions_schema = schemas.Versions(**versions)
         
         for log in cap_logs:
-            # if 'request_id' in log:
-            assert 'request_id' in log
-            assert 'log_level' in log
-            assert log.get('log_level') == 'info'
-            # assert type(log.get('request_id')) == None
+            if log.get('event') == 'Constructing get_versions() response from graph':
+                assert 'request_id' in log
+                assert 'log_level' in log
+                assert log.get('log_level') == 'info'
+                assert type(log.get('request_id')) == None
 
 def test_context_store_logger_returns_request_id():
     with capture_logs() as cap_logs: 
         context_store = ContextStore()
-        context = context_store.get_context(request_id=3)
+        context = context_store.get_context(request_id='96a101dd-c49a-4fea-aee2-a76510f32190')
 
         for log in cap_logs:
-                # if 'request_id' in log:
+            if log.get('event') == 'Getting Context':
                 assert 'request_id' in log
                 assert 'log_level' in log
                 assert log.get('log_level') == 'info'
-                # assert type(log.get('request_id')) == None
+                assert type(log.get('request_id')) == str
 
 def test_context_store_logger_request_id_is_none():
     with capture_logs() as cap_logs: 
@@ -102,11 +102,11 @@ def test_context_store_logger_request_id_is_none():
         context = context_store.get_context(request_id=None)
 
         for log in cap_logs:
-                # if 'request_id' in log:
+            if log.get('event') == 'Getting Context':
                 assert 'request_id' in log
                 assert 'log_level' in log
                 assert log.get('log_level') == 'info'
-                # assert type(log.get('request_id')) == None
+                assert type(log.get('request_id')) == None
 
 def test_csv_stub_logger_returns_request_id():
     """
@@ -116,14 +116,14 @@ def test_csv_stub_logger_returns_request_id():
     """
     with capture_logs() as cap_logs:
         csv_store = StubCsvStore()
-        csv = csv_store.get_version(request_id=3)
+        csv = csv_store.get_version(request_id='96a101dd-c49a-4fea-aee2-a76510f32190')
 
         for log in cap_logs:
-                # if 'request_id' in log:
+            if log.get('event') == 'Recieved request for csv':
                 assert 'request_id' in log
                 assert 'log_level' in log
                 assert log.get('log_level') == 'info'
-                # assert type(log.get('request_id')) == None
+                assert type(log.get('request_id')) == str
 
 def test_csv_stub_logger_request_id_is_none():
     """
@@ -136,11 +136,11 @@ def test_csv_stub_logger_request_id_is_none():
         csv = csv_store.get_version(request_id=None)
 
         for log in cap_logs:
-                # if 'request_id' in log:
+            if log.get('event') == 'Recieved request for csv':
                 assert 'request_id' in log
                 assert 'log_level' in log
                 assert log.get('log_level') == 'info'
-                # assert type(log.get('request_id')) == None
+                assert type(log.get('request_id')) == None
 
 def test_stub_get_dataset_logger_returns_request_id():
     """
@@ -152,14 +152,14 @@ def test_stub_get_dataset_logger_returns_request_id():
     with capture_logs() as cap_logs:
         store = StubMetadataStore()
 
-        dataset = store.get_dataset("cpih",request_id=3)
+        dataset = store.get_dataset("cpih",request_id='96a101dd-c49a-4fea-aee2-a76510f32190')
 
         for log in cap_logs:
-                # if 'request_id' in log:
+            if log.get('event') == 'Constructing get_dataset() from files stored on disk':
                 assert 'request_id' in log
                 assert 'log_level' in log
                 assert log.get('log_level') == 'info'
-                # assert type(log.get('request_id')) == None
+                assert type(log.get('request_id')) == str
 
 def test_stub_get_datasets_logger_request_id_is_none():
     """
@@ -174,8 +174,8 @@ def test_stub_get_datasets_logger_request_id_is_none():
         datasets = store.get_datasets(request_id=None)
 
         for log in cap_logs:
-                # if 'request_id' in log:
+            if log.get('event') == 'Constructing get_datasets() from files stored on disk':
                 assert 'request_id' in log
                 assert 'log_level' in log
                 assert log.get('log_level') == 'info'
-                # assert type(log.get('request_id')) == None
+                assert type(log.get('request_id')) == None

--- a/tests/test_custom_logging.py
+++ b/tests/test_custom_logging.py
@@ -1,0 +1,74 @@
+from typing import Optional
+from structlog.testing import capture_logs
+from unittest.mock import MagicMock
+
+from fastapi import status
+from fastapi.exceptions import ResponseValidationError
+from fastapi.testclient import TestClient
+import pytest
+
+from constants import JSONLD
+from main import app, StubMetadataStore
+from tests.fixtures.versions import versions_test_data
+
+from store.metadata.oxigraph.store import OxigraphMetadataStore
+import schemas
+
+ENDPOINT = "datasets/some-dataset-id/editions/some-edition-id/versions"
+
+def test_logger_request_id():
+    """
+    Confirms that:
+
+    - Where we do not have an "accept: application/json+ld" header.
+    - Then store.get_versions() is not called.
+    - Status code 406 is returned.
+    """
+    with capture_logs() as cap_logs:
+        # Create a mock store with a callable mocked get_versions() method
+        mock_metadata_store = MagicMock()
+        # Note: returning a populated list to simulate id is found
+        mock_metadata_store.get_versions = MagicMock(return_value="irrelevant")
+        app.dependency_overrides[StubMetadataStore] = lambda: mock_metadata_store
+
+        client = TestClient(app)
+        response = client.get(ENDPOINT, headers={"Accept": "foo"})
+
+        # Assertions
+        for log in cap_logs:
+            if 'request_id' in log:
+                assert 'log_level' in log
+                assert log.get('log_level') == 'info'
+                assert type(log.get('request_id')) == Optional[int]
+
+def test_oxigraph_get_datasets_logger_returns_request_id():
+    """
+
+    """  
+    with capture_logs() as cap_logs:    
+        store = OxigraphMetadataStore()
+        datasets = store.get_datasets(request_id=8)
+        datasets_schema = schemas.Datasets(**datasets)
+
+        for log in cap_logs:
+            # if 'request_id' in log:
+            assert 'request_id' in log
+            assert 'log_level' in log
+            assert log.get('log_level') == 'info'
+            # assert type(log.get('request_id')) == None
+
+def test_oxigraph_get_versions_returns_valid_structure():
+    """
+    Confirm that the OxigraphMetadataStore.get_versions()
+    function returns a dictionary that matches the Versions
+    schema.
+    """
+    store = OxigraphMetadataStore()
+    versions = store.get_versions("4gc", "2023-09")
+    versions_schema = schemas.Versions(**versions)
+    assert (
+        versions_schema.id
+        == "https://staging.idpd.uk/datasets/4gc/editions/2023-09/versions"
+    )
+    assert versions_schema.type == "hydra:Collection"
+    assert len(versions_schema.versions) == versions_schema.count

--- a/tests/test_custom_logging.py
+++ b/tests/test_custom_logging.py
@@ -92,7 +92,7 @@ def test_oxigraph_get_versions_return_none_for_request_id_in_store_log():
     """ 
     with capture_logs() as cap_logs: 
         store = OxigraphMetadataStore()
-        versions = store.get_versions("4gc", "2023-09", request_id=True)
+        versions = store.get_versions("4gc", "2023-09", request_id=None)
         versions_schema = schemas.Versions(**versions)
         
         for log in cap_logs:


### PR DESCRIPTION
This ticket makes changes to the custom logger so that 'request_id' is added to it. Then at the start of each request handler, request_id is obtained from the env var 'X-Request-ID' and passed into each store method. Each store method now has a new parameter 'request_id: str' and also have at least one logger.info statement that contains the request_id created earlier, regardless of wether request_id has a value or is none.

How to check:
- Check every request handler gathers request_id from env vars and passes request_id into the store methods.
- check every store methods have new parameter 'request_id'
- check every store method has at least one 'logger.info(...., request_id=request_id)'
- (Optional) See if any more logger statements could be placed anywhere a developer would want to know about whats occurred
- check all logger.info statements in store methods make sense/could do with rewording.
- chcek all unit tests in test_custom_logging.py pass.